### PR TITLE
Fix extension help text

### DIFF
--- a/modules/args_parser.py
+++ b/modules/args_parser.py
@@ -28,8 +28,11 @@ def parse_arguments():
     parser.add_argument(
         "-e", "--extension",
         required=True,
-        help="Output format extension (required) (srt, vtt, ttml, etc.)",
-        choices=['srt', 'vtt', 'ttml', 'ssa', 'ass', 'sbv', 'txt'],
+        help=(
+            "Output format extension (required) "
+            "(srt, vtt, ttml, dfxp, xml, ssa, ass, sbv, txt)"
+        ),
+        choices=['srt', 'vtt', 'ttml', 'dfxp', 'xml', 'ssa', 'ass', 'sbv', 'txt'],
         metavar="EXT"
     )
     


### PR DESCRIPTION
## Summary
- document all supported output types in `--extension` help message
- sync argument choices with the documented formats

## Testing
- `python -m py_compile modules/args_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_684738114ef883288f806d8dbf5b3412

## Summary by Sourcery

Synchronise the --extension argument by expanding its help text to list all supported output formats and updating its choices accordingly

Enhancements:
- Expand help text for --extension to explicitly list supported formats including dfxp and xml
- Update choices for --extension to include newly documented formats dfxp and xml